### PR TITLE
Update src/ReactTextCollapse.js

### DIFF
--- a/src/ReactTextCollapse.js
+++ b/src/ReactTextCollapse.js
@@ -52,7 +52,7 @@ export default class ReactTextCollapse extends Component {
             <div
               style={{
                 display: `block`,
-                overflow: `hidden`,
+                overflow: (collapse ? `hidden` : `auto`),
                 height: `${h}` + 'px'
               }}
             >


### PR DESCRIPTION
Hi, I think this would be better.
I just added overflow option `(collapse ? "hidden" : "auto")` like this because if maxheight is shorter than text height, it shows not correctly like this
<img width="276" alt="2018-11-14 4 16 01" src="https://user-images.githubusercontent.com/44221844/48466248-a0dd6580-e828-11e8-993a-ba1b466123cc.png">
So I'd like to change this option..